### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python"
+run = "python app.py"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,5 @@
 Python Investopedia Stock Picking Bot that generates consistent positive returns by utilizing Python algorithm to trade DOW contracts.
 Automates live feed using kirkthaker's Investopedia paper trading stock simulator API which required the use of XML processing using Element Trees libraries.
 Data mines live feed from various websites for live Index Pricing and Volatility by parsing HTML.
-
-Work-in-Progress:
+[![Run on Repl.it](https://repl.it/badge/github/Macintoshxz/PyInTrade)](https://repl.it/github/Macintoshxz/PyInTrade)Work-in-Progress:
 Multiple Options trading. (currently implemented: Black-Scholes binary option pricing)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JonScarth/PyInTrade).